### PR TITLE
feat: impl Display for IndexedMerkleTree

### DIFF
--- a/src/tree.rs
+++ b/src/tree.rs
@@ -5,6 +5,7 @@ use serde::{Deserialize, Serialize};
 use crate::error::MerkleTreeError;
 use crate::node::{InnerNode, LeafNode, Node};
 use crate::{sha256_mod, Hash};
+use std::fmt;
 
 // `MerkleProof` contains the root hash and a `Vec<Node>>` following the path from the leaf to the root.
 #[derive(Serialize, Deserialize, Debug, Clone)]
@@ -148,6 +149,16 @@ pub enum Proof {
 #[derive(Serialize, Deserialize, Clone)]
 pub struct IndexedMerkleTree {
     pub nodes: Vec<Node>,
+}
+
+impl fmt::Display for IndexedMerkleTree {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        if f.alternate() {
+            self.fmt_mermaid(f)
+        } else {
+            self.fmt_tree(f)
+        }
+    }
 }
 
 impl IndexedMerkleTree {
@@ -524,6 +535,117 @@ impl IndexedMerkleTree {
             first_proof,
             second_proof,
         })
+    }
+
+    fn fmt_tree(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fn write_node(
+            f: &mut fmt::Formatter<'_>,
+            node: &Node,
+            depth: usize,
+            is_last: bool,
+            prefix: &str,
+        ) -> fmt::Result {
+            let indent = if is_last { "└── " } else { "├── " };
+            let node_prefix = format!("{}{}", prefix, indent);
+
+            match node {
+                Node::Inner(inner) => {
+                    writeln!(f, "{}Inner Node (Hash: {})", node_prefix, inner.hash)?;
+                    let new_prefix = format!("{}{}   ", prefix, if is_last { " " } else { "│" });
+                    write_node(f, &inner.left, depth + 1, false, &new_prefix)?;
+                    write_node(f, &inner.right, depth + 1, true, &new_prefix)?;
+                }
+                Node::Leaf(leaf) => {
+                    writeln!(
+                        f,
+                        "{}Leaf Node (Hash: {}, Active: {}, Label: {}, Value: {}, Next: {})",
+                        node_prefix, leaf.hash, leaf.active, leaf.label, leaf.value, leaf.next
+                    )?;
+                }
+            }
+            Ok(())
+        }
+
+        writeln!(f, "Indexed Merkle Tree:")?;
+        if let Some(root) = self.nodes.last() {
+            write_node(f, root, 0, true, "")?;
+        } else {
+            writeln!(f, "(Empty Tree)")?;
+        }
+        Ok(())
+    }
+
+    fn fmt_mermaid(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        writeln!(f, "graph TD")?;
+
+        let mut node_id = 0;
+
+        fn write_node(
+            f: &mut fmt::Formatter<'_>,
+            node: &Node,
+            parent_id: Option<usize>,
+            is_left: bool,
+            node_id: &mut usize,
+        ) -> fmt::Result {
+            let current_id = *node_id;
+            *node_id += 1;
+
+            match node {
+                Node::Inner(inner) => {
+                    writeln!(f, "    N{current_id}[Inner {:.6}]", inner.hash)?;
+                    if let Some(pid) = parent_id {
+                        writeln!(f, "    N{pid} --> N{current_id}")?;
+                    }
+                    write_node(f, &inner.left, Some(current_id), true, node_id)?;
+                    write_node(f, &inner.right, Some(current_id), false, node_id)?;
+                }
+                Node::Leaf(leaf) => {
+                    let label = if leaf.active { "Active" } else { "Inactive" };
+                    writeln!(f, "    N{current_id}[Leaf {:.6} {}]", leaf.hash, label)?;
+                    if let Some(pid) = parent_id {
+                        writeln!(f, "    N{pid} --> N{current_id}")?;
+                    }
+                }
+            }
+            Ok(())
+        }
+
+        if let Some(root) = self.nodes.last() {
+            write_node(f, root, None, true, &mut node_id)?;
+        } else {
+            writeln!(f, "    N0[Empty Tree]")?;
+        }
+
+        // Add styling
+        writeln!(
+            f,
+            "    classDef inner fill:#87CEFA,stroke:#4682B4,stroke-width:2px;"
+        )?;
+        writeln!(
+            f,
+            "    classDef active fill:#98FB98,stroke:#006400,stroke-width:2px;"
+        )?;
+        writeln!(
+            f,
+            "    classDef inactive fill:#FFA07A,stroke:#8B0000,stroke-width:2px;"
+        )?;
+        writeln!(f, "    class N0 inner;")?;
+        for i in 1..node_id {
+            writeln!(
+                f,
+                "    class N{} {};",
+                i,
+                if i < self.nodes.len() / 2 {
+                    "inner"
+                } else if self.nodes[i].is_active() {
+                    "active"
+                } else {
+                    "inactive"
+                }
+            )?;
+        }
+
+        Ok(())
     }
 }
 

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -584,7 +584,6 @@ impl IndexedMerkleTree {
             f: &mut fmt::Formatter<'_>,
             node: &Node,
             parent_id: Option<usize>,
-            is_left: bool,
             node_id: &mut usize,
         ) -> fmt::Result {
             let current_id = *node_id;
@@ -592,16 +591,23 @@ impl IndexedMerkleTree {
 
             match node {
                 Node::Inner(inner) => {
-                    writeln!(f, "    N{current_id}[Inner {:.6}]", inner.hash)?;
+                    writeln!(
+                        f,
+                        "    N{current_id}[Inner {:.6}]",
+                        &inner.hash.to_string()[..8]
+                    )?;
                     if let Some(pid) = parent_id {
                         writeln!(f, "    N{pid} --> N{current_id}")?;
                     }
-                    write_node(f, &inner.left, Some(current_id), true, node_id)?;
-                    write_node(f, &inner.right, Some(current_id), false, node_id)?;
+                    write_node(f, &inner.left, Some(current_id), node_id)?;
+                    write_node(f, &inner.right, Some(current_id), node_id)?;
                 }
                 Node::Leaf(leaf) => {
-                    let label = if leaf.active { "Active" } else { "Inactive" };
-                    writeln!(f, "    N{current_id}[Leaf {:.6} {}]", leaf.hash, label)?;
+                    writeln!(
+                        f,
+                        "    N{current_id}[Hash: n{:.6}...\\nNext: {:.6}...\\nLabel: {:.6}...\\nValue: {:.6}...\\n]",
+                        &leaf.hash.to_string()[..8], &leaf.next.to_string()[..8], &leaf.label.to_string()[..8], &leaf.value.to_string()[..8]
+                    )?;
                     if let Some(pid) = parent_id {
                         writeln!(f, "    N{pid} --> N{current_id}")?;
                     }
@@ -611,7 +617,7 @@ impl IndexedMerkleTree {
         }
 
         if let Some(root) = self.nodes.last() {
-            write_node(f, root, None, true, &mut node_id)?;
+            write_node(f, root, None, &mut node_id)?;
         } else {
             writeln!(f, "    N0[Empty Tree]")?;
         }
@@ -619,15 +625,15 @@ impl IndexedMerkleTree {
         // Add styling
         writeln!(
             f,
-            "    classDef inner fill:#87CEFA,stroke:#4682B4,stroke-width:2px;"
+            "    classDef inner fill:#87CEFA,stroke:#4682B4,stroke-width:2px,color:black;"
         )?;
         writeln!(
             f,
-            "    classDef active fill:#98FB98,stroke:#006400,stroke-width:2px;"
+            "    classDef active fill:#98FB98,stroke:#006400,stroke-width:2px,color:black;"
         )?;
         writeln!(
             f,
-            "    classDef inactive fill:#FFA07A,stroke:#8B0000,stroke-width:2px;"
+            "    classDef inactive fill:#FFA07A,stroke:#8B0000,stroke-width:2px,color:black;"
         )?;
         writeln!(f, "    class N0 inner;")?;
         for i in 1..node_id {


### PR DESCRIPTION
Usage

```rust
let tree = IndexedMerkleTree::new_with_size(4).unwrap();
println!("{}", tree);    // Prints the detailed text representation
println!("{:#}", tree);  // Prints the Mermaid.js diagram
```

Example of normal output:
```
Indexed Merkle Tree:
└── Inner Node (Hash: 1d821333fb273738fab90c3426261fd84664f3534c570474cf0d251f72d289be)
    ├── Inner Node (Hash: 68cc903e9fd5b3ca2cc402c551b837cc2a59eb310ad704fc040b5db90886708f)
    │   ├── Leaf Node (Hash: 45413012ed85205493e39795d7ce34545bd8eee04df21c00bd174817a1320af0, Active: true, Label: 0000000000000000000000000000000000000000000000000000000000000000, Value: 0000000000000000000000000000000000000000000000000000000000000000, Next: 459f66c08495399e9f998395f2b0264a540a1220e3469f9e9d2e97305a9769c4)
    │   └── Leaf Node (Hash: 21849123235f5c0232e23ae595c1f9db5077c2da0ef619489951ba9bc852480f, Active: true, Label: 459f66c08495399e9f998395f2b0264a540a1220e3469f9e9d2e97305a9769c4, Value: 2b99292e5eaf001d66f61298bbb8f8105001ab182b0d262dd15d6c16b0f00a07, Next: 73eda753299d7d483339d80809a1d80553bda402fffe5bfeffffffff00000000)
    └── Inner Node (Hash: 3579cee2e005edbc15741c501abfdeff70d792471659c683cd9e75136e9a6c3f)
        ├── Leaf Node (Hash: 56915b7cef9465fd4180e978be0989502ebfe049f4d8c9b8f106f83e7af245b2, Active: false, Label: 0000000000000000000000000000000000000000000000000000000000000000, Value: 0000000000000000000000000000000000000000000000000000000000000000, Next: 73eda753299d7d483339d80809a1d80553bda402fffe5bfeffffffff00000000)
        └── Leaf Node (Hash: 56915b7cef9465fd4180e978be0989502ebfe049f4d8c9b8f106f83e7af245b2, Active: false, Label: 0000000000000000000000000000000000000000000000000000000000000000, Value: 0000000000000000000000000000000000000000000000000000000000000000, Next: 73eda753299d7d483339d80809a1d80553bda402fffe5bfeffffffff00000000)

```

Example of mermaidjs:
```mermaid
graph TD
    N0[Inner 113b95]
    N1[Inner 008a59]
    N0 --> N1
    N2[Hash: n05c760...\nNext: 010101...\nLabel: 000000...\nValue: 000000...\n]
    N1 --> N2
    N3[Hash: n697962...\nNext: 040404...\nLabel: 010101...\nValue: 020202...\n]
    N1 --> N3
    N4[Inner 466106]
    N0 --> N4
    N5[Hash: n696c75...\nNext: 73eda7...\nLabel: 040404...\nValue: 050505...\n]
    N4 --> N5
    N6[Hash: n56915b...\nNext: 73eda7...\nLabel: 000000...\nValue: 000000...\n]
    N4 --> N6
    classDef inner fill:#87CEFA,stroke:#4682B4,stroke-width:2px,color:black;
    classDef active fill:#98FB98,stroke:#006400,stroke-width:2px,color:black;
    classDef inactive fill:#FFA07A,stroke:#8B0000,stroke-width:2px,color:black;
    class N0 inner;
    class N1 inner;
    class N2 active;
    class N3 active;
    class N4 inner;
    class N5 active;
    class N6 inactive;
```
